### PR TITLE
Posible solucion al deadloock de cheese con cui

### DIFF
--- a/control/control/cerebro.py
+++ b/control/control/cerebro.py
@@ -97,6 +97,9 @@ def main(args=None):
     rclpy.init(args=args)
 
     salem_brain = ControlNode()
+    executor = MutuallyExclusiveCallbackGroup()
+    # Esto deberia permitir que salem ejecute peticiones asincronas
+    executor.add_node(salem_brain)
     salem_brain.go_salem()
     rclpy.spin(salem_brain)
 

--- a/control/control/cerebro.py
+++ b/control/control/cerebro.py
@@ -97,7 +97,7 @@ def main(args=None):
     rclpy.init(args=args)
 
     salem_brain = ControlNode()
-    executor = MutuallyExclusiveCallbackGroup()
+    executor = MultiThreadedExecutor
     # Esto deberia permitir que salem ejecute peticiones asincronas
     executor.add_node(salem_brain)
     salem_brain.go_salem()

--- a/control/control/manejoClientes.py
+++ b/control/control/manejoClientes.py
@@ -12,8 +12,9 @@ class ActionClientManager():
     a los clientes que se conectan con action services 
     '''
     def __init__(self,node,action_type, action_name):
-
-        self.client = ActionClient(node, action_type, action_name)
+        # Esto es para evitar los dealocks por usar el mismo grupo para el manejo de callbacks
+        group = ReentrantCallbackGroup()
+        self.client = ActionClient(node, action_type, action_name,callback_group=group)
         self.node = node
         self.__goal_future = None
         self.__result_future = None
@@ -107,7 +108,7 @@ class ClientAsync(Node):
     def __init__(self, client_name, interface_type, service_name):
         super().__init__(client_name)
         #Esto es para evitar los dealocks por usar el mismo grupo para el manejo de callbacks
-        group = MutuallyExclusiveCallbackGroup()
+        group = ReentrantCallbackGroup()
         self.cli = self.create_client(interface_type,
                                       service_name, 
                                       callback_group=group)


### PR DESCRIPTION
# Executors rapidito

Un executor, es la entidad en ros encargada de distribuir el trabjo solicitado por el usuario a los hilos del sistema operativo nativo.

Hay 3 tipos de executors: 

-  **Multi-Threaded Executor** : Este tipo de ejecutor es el que necesita el modulo de contro, pues permite que cohexistan varios procesos ejecutandose  de manera paralea. 

```python
executor = MultiThreadedExecutor()
executor.add_node(node)
```

-  **Single-Threaded Executor** : Solo maneja un proceso a la vez. 

- **The Static Single-Threaded Executor**: Este es como un ejecutor de inicializacion, y lo que hace es ejecutar las rutinas de busqueda de mensajes en topicos una sola vez en cuanto el nodo es agregado al grupo. 


Agregar un nodo a cierto tipo de executor, no crea el paralelismo en si, para eso es necesario hacer uso de los callback groups:

# Callback groups

Por defecto todos los nodos comparten  un mismo calback gruop, podemos pensar en estos como las entidades encargadas de manejar las funciones de respuesta ante eventos que suucedan en el ambiente de ros. Es comun al trabajar con multiples procesos que queremos que sean paralelos, crear deadlocks  al solicitar dos servicios que utilizan el mismo callback group. Pues el primero consumirá los recursos de busqueda, impidiendo que el segundo se ejecute.

Para dos procesos que queremos que corran en paralelo, entonces debemos cumplir dos requisitos.

1. El nodo principal debe estar asignado a un executor multithread
2. Los callback groups de los procesos deben ser diferentes,o si se desean que lo compartan se debe indicar que este sera multi-nucleo con: `client_cb_group = ReentrantCallbackGroup()`

```
client_cb_group = MutuallyExclusiveCallbackGroup()
timer_cb_group = MutuallyExclusiveCallbackGroup()

self.client = self.create_client(Empty, 'test_service', callback_group=client_cb_group)
self.call_timer = self.create_timer(1, self._timer_cb, callback_group=timer_cb_group)
```

## La solucion que se me ocurrio
Primero, asigne el nodo principal de salem a un grupo de ejecucion multi-hilo
Cambie la implementacion de los clientes para que sean asignados a callbacks diferentes